### PR TITLE
Add resource-pack withdraw UI and Script API example

### DIFF
--- a/addon_backpack/resource_pack/manifest.json
+++ b/addon_backpack/resource_pack/manifest.json
@@ -1,0 +1,17 @@
+{
+  "format_version": 2,
+  "header": {
+    "name": "Infinite Backpack UI",
+    "description": "UI Resource Pack cho màn hình rút item (gộp theo tên)",
+    "uuid": "9123bbc7-b030-4cf6-88aa-ada90a284587",
+    "version": [1, 0, 0],
+    "min_engine_version": [1, 20, 0]
+  },
+  "modules": [
+    {
+      "type": "resources",
+      "uuid": "66582a75-285e-4654-a8ed-83573ee5f8f3",
+      "version": [1, 0, 0]
+    }
+  ]
+}

--- a/addon_backpack/resource_pack/ui/_ui_defs.json
+++ b/addon_backpack/resource_pack/ui/_ui_defs.json
@@ -1,0 +1,5 @@
+{
+  "ui_defs": [
+    "ui/withdraw_items_screen.json"
+  ]
+}

--- a/addon_backpack/resource_pack/ui/withdraw_items_screen.json
+++ b/addon_backpack/resource_pack/ui/withdraw_items_screen.json
@@ -1,0 +1,117 @@
+{
+  "namespace": "backpack",
+  "__comment": "Màn hình rút item - danh sách cuộn, icon item_renderer bên trái.",
+  "backpack_withdraw_screen": {
+    "type": "screen",
+    "anchor_from": "center",
+    "anchor_to": "center",
+    "size": [360, 270],
+    "__comment_header": "Khung chính, dùng stack_panel dọc để chia tiêu đề + danh sách.",
+    "controls": {
+      "root_panel": {
+        "type": "panel",
+        "size": ["100%", "100%"],
+        "controls": {
+          "content_stack": {
+            "type": "stack_panel",
+            "orientation": "vertical",
+            "size": ["100%", "100%"],
+            "controls": {
+              "title_panel": {
+                "type": "panel",
+                "size": ["100%", 28],
+                "controls": {
+                  "title_label": {
+                    "type": "label",
+                    "text": "📦 Rút Items (gộp theo tên)",
+                    "font_size": 16,
+                    "text_alignment": "center",
+                    "anchor_from": "center",
+                    "anchor_to": "center",
+                    "offset": [0, 0]
+                  }
+                }
+              },
+              "divider": {
+                "type": "image",
+                "size": ["100%", 2],
+                "color": [0.2, 0.2, 0.2, 0.9]
+              },
+              "list_panel": {
+                "type": "scroll_panel",
+                "size": ["100%", "100%"],
+                "anchor_from": "top_left",
+                "anchor_to": "top_left",
+                "controls": {
+                  "item_list": {
+                    "type": "collection_panel",
+                    "collection_name": "items",
+                    "item_template": "item_row",
+                    "size": ["100%", "100%"],
+                    "orientation": "vertical",
+                    "item_spacing": 2
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "__comment_row": "Template dòng item: icon 32x32 bên trái + label bên phải, cao ~40px.",
+      "item_row": {
+        "type": "panel",
+        "size": ["100%", 40],
+        "controls": {
+          "row_button": {
+            "type": "button",
+            "size": ["100%", "100%"],
+            "hover_color": [0.25, 0.25, 0.25, 0.9],
+            "pressed_color": [0.4, 0.4, 0.4, 0.9],
+            "controls": {
+              "row_content": {
+                "type": "stack_panel",
+                "orientation": "horizontal",
+                "anchor_from": "left",
+                "anchor_to": "left",
+                "offset": [8, 0],
+                "size": ["100%", "100%"],
+                "controls": {
+                  "item_icon": {
+                    "type": "item_renderer",
+                    "size": [32, 32],
+                    "anchor_from": "left",
+                    "anchor_to": "left",
+                    "offset": [0, 4],
+                    "item_name": "#item_id"
+                  },
+                  "text_stack": {
+                    "type": "stack_panel",
+                    "orientation": "vertical",
+                    "anchor_from": "left",
+                    "anchor_to": "left",
+                    "offset": [10, 2],
+                    "size": ["100%", "100%"],
+                    "controls": {
+                      "item_name_label": {
+                        "type": "label",
+                        "text": "#item_name",
+                        "font_size": 14,
+                        "text_alignment": "left"
+                      },
+                      "item_total_label": {
+                        "type": "label",
+                        "text": "Tổng: §e#total_amount",
+                        "font_size": 12,
+                        "text_alignment": "left"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/addon_backpack/scripts/withdraw_ui_example.js
+++ b/addon_backpack/scripts/withdraw_ui_example.js
@@ -1,0 +1,89 @@
+import { ItemStack, world } from "@minecraft/server";
+import { uiManager } from "@minecraft/server-ui";
+
+const SCREEN_ID = "backpack:backpack_withdraw_screen";
+
+function formatItemName(typeId) {
+  const raw = String(typeId || "").replace("minecraft:", "");
+  return raw
+    .split("_")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : ""))
+    .join(" ");
+}
+
+function getDisplayName(typeId) {
+  try {
+    const sample = new ItemStack(typeId, 1);
+    const display = sample.getComponent("minecraft:display_name");
+    if (display?.value) return display.value;
+  } catch (e) {
+    // fallback below
+  }
+  return formatItemName(typeId);
+}
+
+function safeItemId(typeId) {
+  try {
+    new ItemStack(typeId, 1);
+    return typeId;
+  } catch (e) {
+    return "minecraft:barrier";
+  }
+}
+
+/**
+ * Nhận dữ liệu store (map typeId -> amount) và gộp theo tên hiển thị.
+ * Trả về mảng items phù hợp với UI collection: { item_id, item_name, total_amount }.
+ */
+export function buildWithdrawUiData(store) {
+  const grouped = new Map();
+
+  for (const [typeId, amount] of Object.entries(store || {})) {
+    const total = Number(amount) || 0;
+    if (total <= 0) continue;
+
+    const displayName = getDisplayName(typeId);
+    const entry = grouped.get(displayName) || {
+      item_id: safeItemId(typeId),
+      item_name: displayName,
+      total_amount: 0
+    };
+
+    entry.total_amount += total;
+    grouped.set(displayName, entry);
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => a.item_name.localeCompare(b.item_name));
+}
+
+/**
+ * Mở UI rút item bằng Resource Pack UI.
+ * Yêu cầu bật Experimental: "UI Manager" + Script API.
+ */
+export function openWithdrawScreen(player, store) {
+  if (!uiManager?.get) {
+    player.sendMessage("§cUI Manager không khả dụng. Hãy bật Experimental (UI Manager)." );
+    return;
+  }
+
+  const ui = uiManager.get(player);
+  const items = buildWithdrawUiData(store);
+
+  ui.setData(SCREEN_ID, { items });
+  ui.open(SCREEN_ID);
+}
+
+// Ví dụ: gõ chat "!rut" để mở UI rút items (demo).
+world.beforeEvents.chatSend.subscribe((event) => {
+  if (event.message !== "!rut") return;
+  event.cancel = true;
+  const player = event.sender;
+
+  const store = {
+    "minecraft:birch_log": 128,
+    "minecraft:stone": 512,
+    "minecraft:diamond": 3
+  };
+
+  openWithdrawScreen(player, store);
+});


### PR DESCRIPTION
### Motivation
- Provide a production-ready Resource Pack UI screen for withdrawing items that uses `item_renderer` to show real Minecraft item icons on the left and Vietnamese UX text.
- Support a scrollable, grouped-by-name list so stored items are shown combined by display name and usable on both Mobile and PC Bedrock clients via Resource Pack UI JSON.
- Offer a Script API example to demonstrate how to group store data, supply the `collection_panel` with items and open the screen through the `uiManager`.

### Description
- Added a Resource Pack manifest `resource_pack/manifest.json` and UI registry `resource_pack/ui/_ui_defs.json` to register the screen definition.
- Implemented the screen `resource_pack/ui/withdraw_items_screen.json` with a centered screen titled "📦 Rút Items (gộp theo tên)", a vertical `scroll_panel` containing a `collection_panel` bound to `items`, and an `item_row` template that places an `item_renderer` (32x32) on the left and two labels to the right (name + "Tổng: §e#total_amount").
- Added a Script API example `scripts/withdraw_ui_example.js` that builds grouped UI data via `buildWithdrawUiData(store)` (groups by display name), uses `safeItemId` fallback for missing textures, sets data with `uiManager.get(player).setData(SCREEN_ID, { items })` and opens the screen with `ui.open(SCREEN_ID)`.

### Testing
- No automated tests were executed for these resource-pack and script additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b75aee270833090129b7b06cb10c7)