### PR TITLE
Portable open for Infinite Chest + Vietnamese localization

### DIFF
--- a/InfiniteChest-2.2/InfiniteChestRP-2.2/texts/vi_VN.lang
+++ b/InfiniteChest-2.2/InfiniteChestRP-2.2/texts/vi_VN.lang
@@ -1,0 +1,2 @@
+tile.chest:infinite_chest.name=Rương Vô Hạn
+item.chest:settings.name=Cài đặt Rương Vô Hạn


### PR DESCRIPTION
### Motivation
- Allow players to open the Infinite Chest by right-clicking while holding the item (portable/open-in-hand) instead of placing it first. 
- Provide Vietnamese UX strings so the add-on is usable for Vietnamese servers/players. 
- Keep chest open behavior stable and avoid accidental cleanup when opened from the item (server-side safety).

### Description
- Implemented a portable-open flow by adding `ensureTempEntityAt`, a boolean `openedFromItem` flag, and `getPortableChestLocation` to spawn/teleport the temp chest in front of the player when using the `chest:infinite_chest` item.  (changes in `InfiniteChestBP-2.2/scripts/index.js`)
- Updated tick/cleanup logic so a temp chest opened from the item persists while the player holds the item and only cleans up when the player stops holding it, using `isHoldingInfiniteChestItem` checks and `openedFromItem` state. (changes in `InfiniteChestBP-2.2/scripts/index.js`)
- Added helper `ensureChestManager` to lazily initialize the `InfiniteChestManager` and continued running the chest tick loop; ensure manager is created at player spawn and on item use. (changes in `InfiniteChestBP-2.2/scripts/index.js`)
- Localized in-script UI/messages to Vietnamese (nameTags, action form titles/buttons, confirmation text, message feedback, item nameTags/lore), and added `vi_VN.lang` with `tile.chest:infinite_chest.name` and `item.chest:settings.name` for the resource pack. (changes in `InfiniteChestBP-2.2/scripts/index.js` and new file `InfiniteChestRP-2.2/texts/vi_VN.lang`)

### Testing
- No automated tests were executed as part of this change (no CI run requested). 
- Manual runtime behaviors to validate (recommended): spawn/open via item use, hold item and verify chest persists, release item and verify cleanup, and verify Vietnamese text shows in UI and name tags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c4e00bea48330bbb9ce2848734c5f)