### PR TITLE
Buff villager trades and add rare books

### DIFF
--- a/Infinite_Villager_Trades/manifest.json
+++ b/Infinite_Villager_Trades/manifest.json
@@ -1,8 +1,8 @@
 {
 	"format_version": 2,
 	"header": {
-		"name": "Infinite Villager Trades",
-		"description": "[By ItsMeXD] Ability to Endlessly Trade to Villagers",
+		"name": "Giao Dịch Dân Làng Vô Hạn",
+		"description": "[By ItsMeXD] Buff giá rẻ đồ xịn cho dân làng + Wandering Trader bán sách hiếm",
 		"uuid": "1a877b7d-dda1-4801-b85c-cb1c5d1a6828",
 		"version": [
 			1,

--- a/Infinite_Villager_Trades/trading/economy_trades/armorer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/armorer_trades.json
@@ -33,7 +33,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 7,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],
@@ -51,7 +51,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -69,7 +69,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -87,7 +87,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 9,
+                  "quantity": 5,
                   "price_multiplier": 0.2
                 }
               ],
@@ -138,7 +138,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 36,
+                  "quantity": 18,
                   "price_multiplier": 0.2
                 }
               ],
@@ -174,7 +174,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -266,7 +266,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -284,7 +284,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -312,7 +312,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 14,
+                  "quantity": 7,
                   "price_multiplier": 0.2
                 }
               ],
@@ -340,7 +340,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 8,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],
@@ -378,7 +378,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 8,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],
@@ -406,7 +406,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 16,
+                  "quantity": 8,
                   "price_multiplier": 0.2
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/butcher_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/butcher_trades.json
@@ -160,7 +160,7 @@
       "total_exp_required": 70,
       "groups": [
         {
-        "num_to_select": 1,
+          "num_to_select": 1,
           "trades": [
             {
               "wants": [

--- a/Infinite_Villager_Trades/trading/economy_trades/cartographer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/cartographer_trades.json
@@ -1,1252 +1,1252 @@
 {
-    "tiers": [
-      {
-        "total_exp_required": 0,
-        "groups": [
-          {
-            "num_to_select": 2,
-            "trades": [
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:paper",
-                    "quantity": 24,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 2,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 7,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:empty_map",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 1,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "total_exp_required": 10,
-        "groups": [
-          {
-            "num_to_select": 2,
-            "trades": [
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:glass_pane",
-                    "quantity": 11,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 10,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
-                          {
-                            "function": "exploration_map",
-                            "destination": "village_taiga"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 0,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 4,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 5,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
+  "tiers": [
+    {
+      "total_exp_required": 0,
+      "groups": [
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "total_exp_required": 10,
+      "groups": [
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
                         }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
+                      ],
+                      "filters": {
+                        "all_of": [
                           {
-                            "function": "exploration_map",
-                            "destination": "swamp_hut"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 2,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 4,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 6,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
                           {
-                            "function": "exploration_map",
-                            "destination": "village_snowy"
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
                           }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 5,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 6,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
+                        ]
                       }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
-                          {
-                            "function": "exploration_map",
-                            "destination": "village_savanna"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 0,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 1,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 2,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
-                          {
-                            "function": "exploration_map",
-                            "destination": "village_plains"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 1,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 3,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 4,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 6,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
-                          {
-                            "function": "exploration_map",
-                            "destination": "jungle_temple"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 1,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 3,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 5,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:map",
-                        "quantity": 1,
-                        "functions": [
-                          {
-                            "function": "exploration_map",
-                            "destination": "village_desert"
-                          }
-                        ],
-                        "filters": {
-                          "all_of": [
-                            {
-                              "test": "in_overworld",
-                              "subject": "self",
-                              "value": true,
-                              "operator": "="
-                            },
-                            {
-                              "any_of": [
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 2,
-                                  "operator": "="
-                                },
-                                {
-                                  "test": "is_mark_variant",
-                                  "subject": "self",
-                                  "value": 3,
-                                  "operator": "="
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 5,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "total_exp_required": 70,
-        "groups": [
-          {
-            "num_to_select": 2,
-            "trades": [
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 20,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 13,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:map",
-                    "quantity": 1,
-                    "functions": [
-                      {
-                        "function": "exploration_map",
-                        "destination": "monument"
-                      }
-                    ],
-                    "filters": {
-                      "test": "in_overworld",
-                      "subject": "self",
-                      "value": true,
-                      "operator": "="
                     }
-                  }
-                ],
-                "trader_exp": 10,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 12,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:map",
-                    "quantity": 1,
-                    "functions": [
-                      {
-                        "function": "exploration_map",
-                        "destination": "trial_chambers"
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "filters": {
-                      "test": "in_overworld",
-                      "subject": "self",
-                      "value": true,
-                      "operator": "="
                     }
-                  }
-                ],
-                "trader_exp": 10,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "total_exp_required": 150,
-        "groups": [
-          {
-            "num_to_select": 2,
-            "trades": [
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 7,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:frame",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:4",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 4,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 6,
-                              "operator": "="
-                            }
-                          ]
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
                         }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:15",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 0,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 4,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:1",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 3,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 4,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:2",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 1,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 2,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 3,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:10",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 1,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 6,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:5",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 5,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 6,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:6",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 1,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 4,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:11",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 0,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 2,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:14",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 1,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 3,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:3",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 0,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 2,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:13",
-                        "quantity": 1,
-                        "filters": {
-                          "test": "is_mark_variant",
-                          "subject": "self",
-                          "value": 3,
-                          "operator": "="
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:12",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 4,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 5,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:9",
-                        "quantity": 1,
-                        "filters": {
-                          "any_of": [
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 0,
-                              "operator": "="
-                            },
-                            {
-                              "test": "is_mark_variant",
-                              "subject": "self",
-                              "value": 6,
-                              "operator": "="
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner:8",
-                        "quantity": 1,
-                        "filters": {
-                          "test": "is_mark_variant",
-                          "subject": "self",
-                          "value": 1,
-                          "operator": "="
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 2,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "choice": [
-                      {
-                        "item": "minecraft:banner",
-                        "quantity": 1,
-                        "filters": {
-                          "test": "is_mark_variant",
-                          "subject": "self",
-                          "value": 5,
-                          "operator": "="
-                        }
-                      }
-                    ]
-                  }
-                ],
-                "trader_exp": 15,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "total_exp_required": 250,
-        "groups": [
-          {
-            "num_to_select": 2,
-            "trades": [
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 8,
-                    "price_multiplier": 0.05
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:globe_banner_pattern",
-                    "quantity": 1
-                  }
-                ],
-                "trader_exp": 30,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              },
-              {
-                "wants": [
-                  {
-                    "item": "minecraft:emerald",
-                    "quantity": 14,
-                    "price_multiplier": 0.05
-                  },
-                  {
-                    "item": "minecraft:compass",
-                    "quantity": 1
-                  }
-                ],
-                "gives": [
-                  {
-                    "item": "minecraft:map",
-                    "quantity": 1,
-                    "functions": [
-                      {
-                        "function": "exploration_map",
-                        "destination": "mansion"
-                      }
-                    ],
-                    "filters": {
-                      "test": "in_overworld",
-                      "subject": "self",
-                      "value": true,
-                      "operator": "="
                     }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "total_exp_required": 70,
+      "groups": [
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
                   }
-                ],
-                "trader_exp": 30,
-                "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-                "reward_exp": true
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "total_exp_required": 150,
+      "groups": [
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "total_exp_required": 250,
+      "groups": [
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Infinite_Villager_Trades/trading/economy_trades/cleric_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/cleric_trades.json
@@ -135,7 +135,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -204,7 +204,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.05
                 }
               ],
@@ -255,7 +255,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/farmer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/farmer_trades.json
@@ -207,7 +207,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -295,7 +295,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -313,7 +313,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/fisherman_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/fisherman_trades.json
@@ -1,5 +1,5 @@
 {
-  "format_version":"1.18.10",
+  "format_version": "1.18.10",
   "tiers": [
     {
       "total_exp_required": 0,
@@ -52,7 +52,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -125,7 +125,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
               ],
@@ -198,7 +198,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -280,12 +280,17 @@
             {
               "wants": [
                 {
-                  "choice" : [
+                  "choice": [
                     {
                       "item": "minecraft:oak_boat",
                       "quantity": 1,
                       "price_multiplier": 0.05,
-                      "filters": { "test": "is_mark_variant", "subject": "self", "value": 0, "operator": "="}
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
                     },
                     {
                       "item": "minecraft:spruce_boat",
@@ -293,8 +298,18 @@
                       "price_multiplier": 0.05,
                       "filters": {
                         "any_of": [
-                          { "test": "is_mark_variant", "subject": "self", "value": 4, "operator": "="},
-                          { "test": "is_mark_variant", "subject": "self", "value": 6, "operator": "="}
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
                         ]
                       }
                     },
@@ -304,8 +319,18 @@
                       "price_multiplier": 0.05,
                       "filters": {
                         "any_of": [
-                          { "test": "is_mark_variant", "subject": "self", "value": 1, "operator": "="},
-                          { "test": "is_mark_variant", "subject": "self", "value": 2, "operator": "="}
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
                         ]
                       }
                     },
@@ -313,13 +338,23 @@
                       "item": "minecraft:acacia_boat",
                       "quantity": 1,
                       "price_multiplier": 0.05,
-                      "filters": { "test": "is_mark_variant", "subject": "self", "value": 3, "operator": "="}
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
                     },
                     {
                       "item": "minecraft:dark_oak_boat",
                       "quantity": 1,
                       "price_multiplier": 0.05,
-                      "filters": { "test": "is_mark_variant", "subject": "self", "value": 5, "operator": "="}
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
                     }
                   ]
                 }

--- a/Infinite_Villager_Trades/trading/economy_trades/fletcher_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/fletcher_trades.json
@@ -107,7 +107,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
               ],
@@ -158,7 +158,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -209,7 +209,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
               ],
@@ -270,7 +270,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -298,7 +298,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 },
                 {

--- a/Infinite_Villager_Trades/trading/economy_trades/leather_worker_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/leather_worker_trades.json
@@ -33,7 +33,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -56,7 +56,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 7,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],
@@ -112,7 +112,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -135,7 +135,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -191,7 +191,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 7,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],
@@ -247,7 +247,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 6,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -280,7 +280,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -303,7 +303,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 6,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/librarian_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/librarian_trades.json
@@ -33,7 +33,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 9,
+                  "quantity": 5,
                   "price_multiplier": 0.05
                 }
               ],
@@ -246,7 +246,6 @@
         }
       ]
     },
-
     {
       "total_exp_required": 150,
       "groups": [
@@ -254,7 +253,6 @@
           "num_to_select": 1,
           "trades": [
             {
-              // Book and quill can only have a single item per stack
               "wants": [
                 {
                   "item": "minecraft:writable_book",
@@ -286,7 +284,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -304,7 +302,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.05
                 }
               ],
@@ -363,7 +361,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 20,
+                  "quantity": 10,
                   "price_multiplier": 0.05
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/shepherd_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/shepherd_trades.json
@@ -52,7 +52,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
               ],
@@ -332,7 +332,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -424,7 +424,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.05
                 }
               ],
@@ -461,7 +461,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/stone_mason_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/stone_mason_trades.json
@@ -81,7 +81,7 @@
           "reward_exp": true
         }
       ]
-    },    
+    },
     {
       "total_exp_required": 70,
       "trades": [

--- a/Infinite_Villager_Trades/trading/economy_trades/tool_smith_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/tool_smith_trades.json
@@ -138,7 +138,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 36,
+                  "quantity": 18,
                   "price_multiplier": 0.2
                 }
               ],
@@ -217,7 +217,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.2
                 }
               ],
@@ -245,7 +245,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -273,7 +273,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -324,7 +324,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 12,
+                  "quantity": 6,
                   "price_multiplier": 0.2
                 }
               ],
@@ -352,7 +352,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5,
+                  "quantity": 3,
                   "price_multiplier": 0.2
                 }
               ],
@@ -390,7 +390,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 13,
+                  "quantity": 7,
                   "price_multiplier": 0.2
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
@@ -104,7 +104,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -119,7 +120,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 6
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -134,7 +136,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -149,7 +152,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -164,7 +168,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -179,7 +184,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -194,7 +200,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -209,7 +216,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -224,7 +232,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -239,7 +248,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -254,7 +264,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -269,7 +280,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -284,7 +296,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -328,7 +341,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -347,7 +361,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -362,7 +377,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -377,7 +393,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -392,7 +409,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 4
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -407,7 +425,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -422,7 +441,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -437,7 +457,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -452,7 +473,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -467,7 +489,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -482,7 +505,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -497,7 +521,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -512,7 +537,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -527,7 +553,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -542,7 +569,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -557,7 +585,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -572,7 +601,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -587,7 +617,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -602,7 +633,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -617,7 +649,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -632,7 +665,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -647,7 +681,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -662,7 +697,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -677,7 +713,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -692,7 +729,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -707,7 +745,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -722,7 +761,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -737,7 +777,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -752,7 +793,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -767,7 +809,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -782,7 +825,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -797,7 +841,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -812,7 +857,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -827,7 +873,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -842,7 +889,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -857,7 +905,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -872,7 +921,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -887,7 +937,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -902,7 +953,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -917,7 +969,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -932,7 +985,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 5
+                  "quantity": 3,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -947,7 +1001,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -962,7 +1017,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -977,7 +1033,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -992,7 +1049,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1007,7 +1065,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1022,7 +1081,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1037,7 +1097,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1052,7 +1113,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1067,7 +1129,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1082,7 +1145,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1097,7 +1161,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1112,7 +1177,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1127,7 +1193,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1142,7 +1209,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1157,7 +1225,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1172,7 +1241,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1187,7 +1257,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1202,7 +1273,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1217,7 +1289,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1232,7 +1305,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1247,7 +1321,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3
+                  "quantity": 2,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1262,7 +1337,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1277,7 +1353,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1292,7 +1369,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1307,7 +1385,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1322,7 +1401,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1337,7 +1417,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1352,7 +1433,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1367,7 +1449,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1382,7 +1465,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1397,7 +1481,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1412,7 +1497,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1427,7 +1513,8 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 1
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 }
               ],
               "gives": [
@@ -1437,6 +1524,98 @@
                 }
               ],
               "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        {
+                          "id": "mending",
+                          "level": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        {
+                          "id": "frost_walker",
+                          "level": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 3,
+              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        {
+                          "id": "soul_speed",
+                          "level": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 3,
+              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
+              "reward_exp": true
             }
           ]
         }

--- a/Infinite_Villager_Trades/trading/economy_trades/weapon_smith_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/weapon_smith_trades.json
@@ -33,7 +33,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 3,
+                  "quantity": 2,
                   "price_multiplier": 0.2
                 }
               ],
@@ -56,7 +56,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 2,
+                  "quantity": 1,
                   "price_multiplier": 0.2
                 }
               ],
@@ -117,7 +117,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 36,
+                  "quantity": 18,
                   "price_multiplier": 0.2
                 }
               ],
@@ -163,7 +163,6 @@
         }
       ]
     },
-
     {
       "total_exp_required": 150,
       "groups": [
@@ -197,7 +196,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 12,
+                  "quantity": 6,
                   "price_multiplier": 0.2
                 }
               ],
@@ -235,7 +234,7 @@
               "wants": [
                 {
                   "item": "minecraft:emerald",
-                  "quantity": 8,
+                  "quantity": 4,
                   "price_multiplier": 0.2
                 }
               ],


### PR DESCRIPTION
### Motivation
- Giảm giá emerald cho nhiều trade dân làng để người chơi có thể mua đồ xịn với giá rẻ hơn và ưu đãi lớn. 
- Thêm trade đặc biệt cho Wandering Trader bán sách có enchant hiếm (đặc biệt là `mending`) với giới hạn sử dụng rất lớn. 
- Giữ thay đổi ở dạng data-only để an toàn cho server Bedrock RAM thấp và tránh logic nặng cần Script API.

### Description
- Giảm `quantity` yêu cầu emerald ở nhiều file trade trong `trading/economy_trades/*` và thêm `price_multiplier: 0.05` cho các wants emerald để tạo ưu đãi giá rẻ (tự động áp dụng trên ~15 file). 
- Thêm nhóm trade đặc biệt vào `trading/economy_trades/wandering_trader_trades.json` để Wandering Trader bán sách có `specific_enchants` gồm `mending`, `frost_walker` và `soul_speed` với `max_uses` rất lớn. 
- Cập nhật `manifest.json` sang tiếng Việt (`name` và `description`) để phản ánh nội dung mới. 
- Sửa vài chỗ định dạng / loại bỏ comment không hợp lệ trong JSON và chạy sanitize/format lại các file trade để đảm bảo tính hợp lệ JSON.

### Testing
- Đã chạy kiểm tra parse JSON bằng `python` (load tất cả file trong `trading/economy_trades`) sau chỉnh sửa và mọi file modified đều parse thành công. 
- Đã chạy tìm kiếm/so sánh bằng `rg`/script để xác nhận các thay đổi (giảm số lượng emerald, thêm `price_multiplier`) và kết quả khớp như mong đợi. 
- Các thay đổi là data-only nên không có test in-game tự động; không có Script API hay runtime behavior tests được chạy here. 
- Commit chứa 15 file sửa đổi và đã được ghi nhận (data-only update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e241197088330aa7df29d6ae82c20)