### PR TITLE
Mở rộng pool giao dịch dân làng và thêm giao dịch kiếm rẻ (1 emerald → diamond_sword)

### DIFF
--- a/Infinite_Villager_Trades/trading/economy_trades/armorer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/armorer_trades.json
@@ -9,6 +9,29 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:coal:0",
                   "quantity": 15,
                   "price_multiplier": 0.05
@@ -102,6 +125,866 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
@@ -181,6 +1064,1243 @@
               "gives": [
                 {
                   "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
                   "quantity": 1
                 }
               ],
@@ -299,6 +2419,766 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
@@ -365,6 +3245,1308 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
@@ -424,6 +4606,703 @@
                       }
                     }
                   ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
                 }
               ],
               "trader_exp": 30,

--- a/Infinite_Villager_Trades/trading/economy_trades/butcher_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/butcher_trades.json
@@ -9,6 +9,560 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:chicken",
                   "quantity": 14,
                   "price_multiplier": 0.05
@@ -84,12 +638,897 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -153,12 +1592,1263 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -199,12 +2889,880 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -227,12 +3785,1205 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -247,6 +4998,310 @@
               "gives": [
                 {
                   "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
                   "quantity": 1
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/cartographer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/cartographer_trades.json
@@ -4,6 +4,742 @@
       "total_exp_required": 0,
       "groups": [
         {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
           "num_to_select": 2,
           "trades": [
             {
@@ -43,12 +779,884 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 2,
           "trades": [
@@ -513,12 +2121,821 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 2,
           "trades": [
@@ -609,12 +3026,821 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 2,
           "trades": [
@@ -1183,12 +4409,645 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 2,
           "trades": [
@@ -1238,6 +5097,212 @@
                     "value": true,
                     "operator": "="
                   }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
                 }
               ],
               "trader_exp": 30,

--- a/Infinite_Villager_Trades/trading/economy_trades/cleric_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/cleric_trades.json
@@ -9,6 +9,943 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:rotten_flesh",
                   "quantity": 32,
                   "price_multiplier": 0.05
@@ -54,6 +991,1279 @@
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -111,6 +2321,825 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:rabbit_foot",
                   "quantity": 2,
                   "price_multiplier": 0.05
@@ -156,6 +3185,1305 @@
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -225,6 +4553,718 @@
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [

--- a/Infinite_Villager_Trades/trading/economy_trades/farmer_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/farmer_trades.json
@@ -9,6 +9,642 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:wheat",
                   "quantity": 20,
                   "price_multiplier": 0.05
@@ -102,12 +738,861 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -171,12 +1656,1240 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -222,12 +2935,857 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -282,12 +3840,1173 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -325,6 +5044,269 @@
               ],
               "trader_exp": 30,
               "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
               "reward_exp": true
             }
           ]

--- a/Infinite_Villager_Trades/trading/economy_trades/fisherman_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/fisherman_trades.json
@@ -1,9 +1,785 @@
 {
-  "format_version": "1.18.10",
   "tiers": [
     {
       "total_exp_required": 0,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -89,12 +865,1263 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -162,12 +2189,844 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -223,12 +3082,1334 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -251,12 +4432,679 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "trades": [
             {
@@ -362,6 +5210,98 @@
               "gives": [
                 {
                   "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
                   "quantity": 1
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/fletcher_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/fletcher_trades.json
@@ -9,6 +9,129 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:stick",
                   "quantity": 32,
                   "price_multiplier": 0.05
@@ -71,12 +194,885 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -122,12 +1118,1308 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -173,12 +2465,787 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -234,12 +3301,1319 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -465,6 +4839,474 @@
               ],
               "trader_exp": 30,
               "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
               "reward_exp": true
             }
           ]

--- a/Infinite_Villager_Trades/trading/economy_trades/leather_worker_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/leather_worker_trades.json
@@ -9,6 +9,869 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:leather",
                   "quantity": 6,
                   "price_multiplier": 0.05
@@ -76,12 +939,1257 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -155,12 +2263,826 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -211,12 +3133,1306 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -267,12 +4483,742 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -310,6 +5256,52 @@
               "gives": [
                 {
                   "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
                   "quantity": 1
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/librarian_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/librarian_trades.json
@@ -9,6 +9,298 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:paper",
                   "quantity": 24,
                   "price_multiplier": 0.05
@@ -79,12 +371,800 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -161,12 +1241,1361 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -243,12 +2672,720 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -348,12 +3485,1397 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -368,6 +4890,418 @@
               "gives": [
                 {
                   "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
                   "quantity": 1
                 }
               ],

--- a/Infinite_Villager_Trades/trading/economy_trades/shepherd_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/shepherd_trades.json
@@ -9,6 +9,416 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "choice": [
                     {
                       "item": "minecraft:white_wool",
@@ -67,12 +477,812 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -272,12 +1482,1268 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -359,12 +2825,804 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -448,12 +3706,1228 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -469,6 +4943,366 @@
                 {
                   "item": "minecraft:painting",
                   "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
                 }
               ],
               "trader_exp": 30,

--- a/Infinite_Villager_Trades/trading/economy_trades/stone_mason_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/stone_mason_trades.json
@@ -2,320 +2,5314 @@
   "tiers": [
     {
       "total_exp_required": 0,
-      "trades": [
+      "groups": [
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:clay_ball",
-              "quantity": 10,
-              "price_multiplier": 0.05
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "gives": [
-            {
-              "item": "minecraft:emerald",
-              "quantity": 1
-            }
-          ],
-          "trader_exp": 2,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
         },
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:emerald",
-              "quantity": 1,
-              "price_multiplier": 0.05
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "gives": [
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:brick",
-              "quantity": 10
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 1,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 10,
-      "trades": [
+      "groups": [
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:stone",
-              "quantity": 20,
-              "price_multiplier": 0.05
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "gives": [
-            {
-              "item": "minecraft:emerald",
-              "quantity": 1
-            }
-          ],
-          "trader_exp": 10,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
         },
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:emerald",
-              "quantity": 1,
-              "price_multiplier": 0.05
-            }
-          ],
-          "gives": [
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
             {
-              "item": "minecraft:chiseled_stone_bricks",
-              "quantity": 4
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 5,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 70,
-      "trades": [
+      "groups": [
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "choice": [
+              "wants": [
                 {
-                  "item": "minecraft:granite",
-                  "quantity": 16,
-                  "price_multiplier": 0.05
-                },
-                {
-                  "item": "minecraft:diorite",
-                  "quantity": 16,
-                  "price_multiplier": 0.05
-                },
-                {
-                  "item": "minecraft:andesite",
-                  "quantity": 16,
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
                   "price_multiplier": 0.05
                 }
-              ]
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "gives": [
-            {
-              "item": "minecraft:emerald",
-              "quantity": 1
-            }
-          ],
-          "trader_exp": 20,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
         },
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:emerald",
-              "quantity": 1,
-              "price_multiplier": 0.05
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "gives": [
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
-              "choice": [
+              "wants": [
                 {
-                  "item": "minecraft:polished_granite",
-                  "quantity": 4
-                },
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
                 {
-                  "item": "minecraft:polished_diorite",
-                  "quantity": 4
-                },
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
                 {
-                  "item": "minecraft:polished_andesite",
-                  "quantity": 4
-                },
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
                 {
-                  "item": "minecraft:dripstone_block",
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
                   "quantity": 4
                 }
-              ]
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 10,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
-      "trades": [
+      "groups": [
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:quartz",
-              "quantity": 12,
-              "price_multiplier": 0.05
-            }
-          ],
-          "gives": [
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
             {
-              "item": "minecraft:emerald",
-              "quantity": 1
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 30,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
         },
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:emerald",
-              "quantity": 1,
-              "price_multiplier": 0.05
-            }
-          ],
-          "gives": [
-            {
-              "choice": [
+              "wants": [
                 {
-                  "item": "minecraft:white_terracotta"
-                },
-                {
-                  "item": "minecraft:orange_terracotta"
-                },
-                {
-                  "item": "minecraft:magenta_terracotta"
-                },
-                {
-                  "item": "minecraft:light_blue_terracotta"
-                },
-                {
-                  "item": "minecraft:yellow_terracotta"
-                },
-                {
-                  "item": "minecraft:lime_terracotta"
-                },
-                {
-                  "item": "minecraft:pink_terracotta"
-                },
-                {
-                  "item": "minecraft:gray_terracotta"
-                },
-                {
-                  "item": "minecraft:light_gray_terracotta"
-                },
-                {
-                  "item": "minecraft:cyan_terracotta"
-                },
-                {
-                  "item": "minecraft:purple_terracotta"
-                },
-                {
-                  "item": "minecraft:blue_terracotta"
-                },
-                {
-                  "item": "minecraft:brown_terracotta"
-                },
-                {
-                  "item": "minecraft:green_terracotta"
-                },
-                {
-                  "item": "minecraft:red_terracotta"
-                },
-                {
-                  "item": "minecraft:black_terracotta"
-                },
-                {
-                  "item": "minecraft:black_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:blue_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:brown_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:cyan_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:gray_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:green_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:light_blue_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:lime_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:magenta_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:orange_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:pink_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:purple_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:red_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:silver_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:white_glazed_terracotta"
-                },
-                {
-                  "item": "minecraft:yellow_glazed_terracotta"
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
                 }
-              ]
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 15,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
-      "trades": [
+      "groups": [
         {
-          "wants": [
+          "num_to_select": 1,
+          "trades": [
             {
-              "item": "minecraft:emerald",
-              "quantity": 1,
-              "price_multiplier": 0.05
-            }
-          ],
-          "gives": [
-            {
-              "choice": [
+              "wants": [
                 {
-                  "item": "minecraft:quartz_block"
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
                 },
                 {
-                  "item": "minecraft:quartz_pillar"
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
                 }
-              ]
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
-          ],
-          "trader_exp": 30,
-          "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
-          "reward_exp": true
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     }

--- a/Infinite_Villager_Trades/trading/economy_trades/tool_smith_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/tool_smith_trades.json
@@ -9,6 +9,198 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:coal:0",
                   "quantity": 15,
                   "price_multiplier": 0.05
@@ -102,6 +294,697 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
@@ -151,6 +1034,1279 @@
               "trader_exp": 5,
               "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
               "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
           ]
         }
@@ -159,6 +2315,157 @@
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -288,12 +2595,713 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -377,12 +3385,1464 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -408,6 +4868,441 @@
                       }
                     }
                   ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
                 }
               ],
               "trader_exp": 30,

--- a/Infinite_Villager_Trades/trading/economy_trades/weapon_smith_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/weapon_smith_trades.json
@@ -9,6 +9,481 @@
             {
               "wants": [
                 {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_sword",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stick",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 16
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:gravel",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_axe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_shovel",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_pickaxe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:stone_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bookshelf",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clay_ball",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:brick",
+                  "quantity": 10
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:black_wool",
+                      "quantity": 18,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shears",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
                   "item": "minecraft:coal:0",
                   "quantity": 15,
                   "price_multiplier": 0.05
@@ -81,6 +556,435 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:chicken",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:porkchop",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:rabbit_stew",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:wheat",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:potato",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beetroot",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:carrot",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bread",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:paper",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:empty_map",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bucket:2",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_fish",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:leather",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rotten_flesh",
+                  "quantity": 32,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 2,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:redstone",
+                  "quantity": 2
+                }
+              ],
+              "trader_exp": 1,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
@@ -130,6 +1034,1279 @@
               "trader_exp": 5,
               "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
               "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_boots",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_leggings",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:lantern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:stone",
+                  "quantity": 20,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chiseled_stone_bricks",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:black_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:lime_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:white_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_wool"
+                    },
+                    {
+                      "item": "minecraft:orange_wool"
+                    },
+                    {
+                      "item": "minecraft:magenta_wool"
+                    },
+                    {
+                      "item": "minecraft:light_blue_wool"
+                    },
+                    {
+                      "item": "minecraft:yellow_wool"
+                    },
+                    {
+                      "item": "minecraft:lime_wool"
+                    },
+                    {
+                      "item": "minecraft:pink_wool"
+                    },
+                    {
+                      "item": "minecraft:gray_wool"
+                    },
+                    {
+                      "item": "minecraft:light_gray_wool"
+                    },
+                    {
+                      "item": "minecraft:cyan_wool"
+                    },
+                    {
+                      "item": "minecraft:purple_wool"
+                    },
+                    {
+                      "item": "minecraft:blue_wool"
+                    },
+                    {
+                      "item": "minecraft:brown_wool"
+                    },
+                    {
+                      "item": "minecraft:green_wool"
+                    },
+                    {
+                      "item": "minecraft:red_wool"
+                    },
+                    {
+                      "item": "minecraft:black_wool"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:orange_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:magenta_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:yellow_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:lime_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:pink_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:light_gray_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:cyan_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:purple_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:blue_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:brown_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:green_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:red_carpet",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:black_carpet",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:iron_ingot",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 18,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bell",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:coal:0",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_chicken",
+                  "quantity": 8
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_porkchop",
+                  "quantity": 5
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pumpkin",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:pumpkin_pie",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:apple",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_pane",
+                  "quantity": 11,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_taiga"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "swamp_hut"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_snowy"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_savanna"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 0,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_plains"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 4,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 6,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "jungle_temple"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 1,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 5,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:map",
+                      "quantity": 1,
+                      "functions": [
+                        {
+                          "function": "exploration_map",
+                          "destination": "village_desert"
+                        }
+                      ],
+                      "filters": {
+                        "all_of": [
+                          {
+                            "test": "in_overworld",
+                            "subject": "self",
+                            "value": true,
+                            "operator": "="
+                          },
+                          {
+                            "any_of": [
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 2,
+                                "operator": "="
+                              },
+                              {
+                                "test": "is_mark_variant",
+                                "subject": "self",
+                                "value": 3,
+                                "operator": "="
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:fish",
+                  "quantity": 15,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:campfire",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 6
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cooked_salmon",
+                  "quantity": 6
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 26,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:gold_ingot",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:dye:4",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 5,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
             }
           ]
         }
@@ -138,6 +2315,517 @@
     {
       "total_exp_required": 70,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:bucket:10",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_helmet",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:chainmail_chestplate",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:shield",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:string",
+                  "quantity": 14,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:flint",
+                  "quantity": 30,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:iron_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_hoe",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dye:0",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glass",
+                  "quantity": 4
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:granite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:diorite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:andesite",
+                      "quantity": 16,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:polished_granite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_diorite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:polished_andesite",
+                      "quantity": 4
+                    },
+                    {
+                      "item": "minecraft:dripstone_block",
+                      "quantity": 4
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:red_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:light_gray_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:pink_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:yellow_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:orange_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:bed",
+                      "functions": [
+                        {
+                          "function": "random_aux_value",
+                          "values": {
+                            "min": 0,
+                            "max": 15
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -160,12 +2848,865 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:beef",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:muttonraw",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:melon_block",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cookie",
+                  "quantity": 18
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "monument"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "trial_chambers"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:salmon",
+                  "quantity": 13,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:fishing_rod",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_hide",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:rabbit_foot",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 20,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:glowstone",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 10,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 150,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_leggings",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:feather",
+                  "quantity": 24,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 6,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_axe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_shovel",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:writable_book",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:clock",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "price_multiplier": 0.2
+                },
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:book",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_book_for_trading",
+                      "base_cost": 2,
+                      "base_random_cost": 5,
+                      "per_level_random_cost": 10,
+                      "per_level_cost": 3
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:quartz",
+                  "quantity": 12,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:white_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_gray_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_terracotta"
+                    },
+                    {
+                      "item": "minecraft:black_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:brown_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:cyan_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:gray_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:green_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:light_blue_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:lime_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:magenta_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:orange_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:pink_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:purple_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:red_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:silver_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:white_glazed_terracotta"
+                    },
+                    {
+                      "item": "minecraft:yellow_glazed_terracotta"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:green_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:brown_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:blue_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:purple_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:cyan_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    },
+                    {
+                      "item": "minecraft:magenta_dye",
+                      "quantity": 12,
+                      "price_multiplier": 0.05
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:banner",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 15
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -221,12 +3762,1195 @@
               "reward_exp": true
             }
           ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:dried_kelp_block",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:suspicious_stew:0",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_aux_value",
+                      "values": {
+                        "min": 0,
+                        "max": 5
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:cake",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:frame",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:4",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:15",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:1",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:2",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:10",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:5",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:6",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:11",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:14",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 3,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:3",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:13",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:12",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 5,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:9",
+                      "quantity": 1,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 0,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner:8",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 1,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:banner",
+                      "quantity": 1,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:clownfish",
+                  "quantity": 6,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:horsearmorleather",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:turtle_shell_piece",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:glass_bottle",
+                  "quantity": 9,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:ender_pearl",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
         }
       ]
     },
     {
       "total_exp_required": 250,
       "groups": [
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 8,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_chestplate",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:tripwire_hook",
+                  "quantity": 8,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:crossbow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 15,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:arrow",
+                  "quantity": 5,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "nightvision"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "invisibility"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "leaping"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "fire_resistance"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "swiftness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "slowness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "water_breathing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "healing"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "harming"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "poison"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "regeneration"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "strength"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "weakness"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "turtle_master"
+                        }
+                      ]
+                    },
+                    {
+                      "item": "minecraft:arrow",
+                      "quantity": 5,
+                      "functions": [
+                        {
+                          "function": "set_potion",
+                          "id": "wither"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_pickaxe",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "enchant_with_levels",
+                      "treasure": false,
+                      "levels": {
+                        "min": 5,
+                        "max": 19
+                      }
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:nametag",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:quartz_block"
+                    },
+                    {
+                      "item": "minecraft:quartz_pillar"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:painting",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
         {
           "num_to_select": 1,
           "trades": [
@@ -252,6 +4976,333 @@
                       }
                     }
                   ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:sweet_berries",
+                  "quantity": 10,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:golden_carrot",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:speckled_melon",
+                  "quantity": 3
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 2,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:globe_banner_pattern",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 7,
+                  "price_multiplier": 0.05
+                },
+                {
+                  "item": "minecraft:compass",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:map",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "exploration_map",
+                      "destination": "mansion"
+                    }
+                  ],
+                  "filters": {
+                    "test": "in_overworld",
+                    "subject": "self",
+                    "value": true,
+                    "operator": "="
+                  }
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:pufferfish",
+                  "quantity": 4,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "choice": [
+                    {
+                      "item": "minecraft:oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 0,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:spruce_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 4,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 6,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:jungle_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "any_of": [
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 1,
+                            "operator": "="
+                          },
+                          {
+                            "test": "is_mark_variant",
+                            "subject": "self",
+                            "value": 2,
+                            "operator": "="
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "item": "minecraft:acacia_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 3,
+                        "operator": "="
+                      }
+                    },
+                    {
+                      "item": "minecraft:dark_oak_boat",
+                      "quantity": 1,
+                      "price_multiplier": 0.05,
+                      "filters": {
+                        "test": "is_mark_variant",
+                        "subject": "self",
+                        "value": 5,
+                        "operator": "="
+                      }
+                    }
+                  ]
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:leather_helmet",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "random_dye"
+                    }
+                  ]
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            },
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 3,
+                  "price_multiplier": 0.2
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:saddle",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:nether_wart",
+                  "quantity": 22,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 1
+                }
+              ],
+              "trader_exp": 30,
+              "max_uses": 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999,
+              "reward_exp": true
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:emerald",
+                  "quantity": 2,
+                  "price_multiplier": 0.05
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:experience_bottle",
+                  "quantity": 1
                 }
               ],
               "trader_exp": 30,


### PR DESCRIPTION
### Motivation

- Tăng tỉ lệ tiếp cận đồ giá trị bằng cách làm `emerald` dễ kiếm hơn và cho phép mọi nghề lấy từ cùng một pool giao dịch thay vì cố định theo nghề.  
- Thêm lựa chọn mua kiếm xịn giá rẻ (mục tiêu: `1 emerald → diamond_sword`) để đáp ứng yêu cầu buff kiếm/emerald.  
- Chuẩn hoá cấu trúc trade (nhất là `stone_mason`) sang dạng `tiers` + `groups` để đồng nhất dữ liệu và dễ bảo trì.

### Description

- Đã chỉnh sửa hàng loạt file dữ liệu giao dịch trong `trading/economy_trades/*.json` để: hợp nhất pool giao dịch giữa các nghề, chuẩn hoá các `tiers` thành bộ level `[0, 10, 70, 150, 250]` và chuyển các bảng kiểu cũ (dùng `trades`) sang `groups` để nhất quán.  
- Thêm trade mới giá rẻ: `wants: minecraft:emerald (quantity:1)` → `gives: minecraft:diamond_sword (quantity:1)` ở level 0 trong nhiều bảng nghề để đảm bảo mọi dân làng có cơ hội bán kiếm xịn.  
- Điều chỉnh nhiều giao dịch: chuẩn hoá các `price_multiplier`, một số `wants`/`gives` được đổi thành `emerald`-first và một số vật phẩm đổi chỗ/điều chỉnh số lượng để cân bằng (ví dụ chuyển `paper`/`stick`/`coal` thành nguồn emerald tiện lợi).  
- Bổ sung/chuẩn hoá các chức năng trade phức tạp như `enchant_with_levels`, `enchant_book_for_trading`, `exploration_map` khi cần và thiết lập `max_uses` rất lớn để trade gần như vô hạn.

### Testing

- Chạy script kiểm tra/chuyển đổi và merge `tiers`: chạy `python` script để tổng hợp tiers và chèn trade kiếm; script in ra `written 13 files with levels [0, 10, 70, 150, 250]` và chạy thành công.  
- Kiểm tra cấu trúc tier/group: trước khi merge đã dùng script để phát hiện `missing groups` (ví dụ `stone_mason_trades.json`) rồi chạy chuẩn hoá; thao tác này thành công và các file được ghi lại.  
- Kiểm tra cơ bản file/diff và commit: dùng `sed`/`nl` để xem nội dung cập nhật ở vài file tiêu biểu và `git commit` báo thành công; không có test tự động in-game Script API/Bedrock runtime được chạy trong rollout (thay đổi là data-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3de393c8833092301eb28dcbbdfb)