### PR TITLE
Update wandering trader trades to single-use diamond-for-gear offers

### DIFF
--- a/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
@@ -3,1527 +3,37 @@
     {
       "groups": [
         {
-          "num_to_select": 2,
+          "num_to_select": 1,
           "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:potion:0",
+                  "item": "minecraft:diamond",
                   "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:water_bucket",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:milk_bucket",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:fermented_spider_eye",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:baked_potato",
-                  "quantity": 4
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:hay_block",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            }
-          ]
-        },
-        {
-          "num_to_select": 2,
-          "trades": [
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:packed_ice",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_ice",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:gunpowder",
-                  "quantity": 4
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:podzol",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:acacia_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:birch_log:2",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dark_oak_log:1",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:jungle_log:3",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oak_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:spruce_log:1",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cherry_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_oak_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:mangrove_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.2
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:iron_pickaxe",
+                  "item": "minecraft:diamond_sword",
                   "quantity": 1,
                   "functions": [
                     {
-                      "function": "enchant_with_levels",
-                      "treasure": false,
-                      "levels": {
-                        "min": 5,
-                        "max": 19
-                      }
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "sharpness", "level": 5 },
+                        { "id": "smite", "level": 5 },
+                        { "id": "bane_of_arthropods", "level": 5 },
+                        { "id": "fire_aspect", "level": 2 },
+                        { "id": "looting", "level": 3 },
+                        { "id": "knockback", "level": 2 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
+                      ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 1,
-              "max_uses": 50,
-              "reward_exp": true
-            },
-            {
-              "max_uses": 50,
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:potion:8",
-                  "quantity": 1
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "num_to_select": 5,
-          "trades": [
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tropical_fish_bucket",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pufferfish_bucket",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sea_pickle",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:slime_ball",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:glowstone",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:nautilus_shell",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:fern",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tall_dry_grass",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sugar_cane",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pumpkin",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:kelp",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cactus",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dandelion",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:poppy",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_orchid",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:allium",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:azure_bluet",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:orange_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:white_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pink_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oxeye_daisy",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cornflower",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:wildflowers",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:firefly_bush",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:lily_of_the_valley",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:open_eyeblossom",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:wheat_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:beetroot_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pumpkin_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:melon_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:acacia_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:birch_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dark_oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:jungle_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:spruce_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cherry_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:mangrove_propagule",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:white_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pink_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:black_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:green_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:light_gray_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:magenta_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:yellow_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:gray_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:purple_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:light_blue_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:lime_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:orange_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brown_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cyan_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brain_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:bubble_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:fire_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:horn_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tube_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:vine",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_hanging_moss",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brown_mushroom",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_mushroom",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:waterlily",
-                  "quantity": 5
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:small_dripleaf_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sand",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_sand",
-                  "quantity": 4
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pointed_dripstone",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dirt_with_roots",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:moss_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_moss_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
+              "max_uses": 1
             }
           ]
         },
@@ -1533,89 +43,173 @@
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 8,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_helmet",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "mending",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "respiration", "level": 3 },
+                        { "id": "aqua_affinity", "level": 1 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 5,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
-            },
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 6,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_chestplate",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "frost_walker",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 3,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
-            },
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 6,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_leggings",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "soul_speed",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "swift_sneak", "level": 3 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 3,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "feather_falling", "level": 4 },
+                        { "id": "frost_walker", "level": 2 },
+                        { "id": "depth_strider", "level": 3 },
+                        { "id": "soul_speed", "level": 3 }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "infinity", "level": 1 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "power", "level": 5 },
+                        { "id": "punch", "level": 2 },
+                        { "id": "flame", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "max_uses": 1
             }
           ]
         }


### PR DESCRIPTION
### Motivation
- Replace the original Wandering Trader trade table (very large multi-item list) with a compact set of single-use trades that sell high-tier enchanted diamond gear for exactly 1 diamond each at the trader.
- Provide the exact requested enchantment sets for the Diamond Sword, Full Diamond Armor pieces, and Bow so players can buy the custom powerful items once per trader spawn.

### Description
- Modified `trading/economy_trades/wandering_trader_trades.json` to replace the previous long list of emerald-based trades with a concise set of trades where each trade `wants` a single `minecraft:diamond` and `gives` one enchanted item (diamond sword, helmet, chestplate, leggings, boots, bow).
- Each `gives` entry uses the `specific_enchants` function to set the exact enchantments and levels requested (e.g., `sharpness V`, `smite V`, `bane_of_arthropods V`, `mending`, `unbreaking III`, armor protections, boots extras, bow enchants, etc.).
- All new trades are single-use by setting `max_uses` to `1` so the trade will disappear after being bought once per trader spawn.
- No other files were changed; the pack `manifest.json` and other trade files remain intact.

### Testing
- Automated tests: none were executed for this data-only change.
- Note: this is a content-only change to a trade JSON file and should be validated by loading the behavior pack in a Bedrock world or server to confirm the Wandering Trader offers the new single-use diamond trades as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6bc70d548330ab3bfe3a1f7afa67)