### PR TITLE
Single-use diamond-for-gear wandering trader trades + spawn/despawn functions

### DIFF
--- a/Infinite_Villager_Trades/functions/ivt_despawn_trader.mcfunction
+++ b/Infinite_Villager_Trades/functions/ivt_despawn_trader.mcfunction
@@ -1,0 +1,2 @@
+# Xóa thương nhân đã triệu hồi nếu còn tồn tại
+kill @e[type=wandering_trader,tag=ivt_custom_trader]

--- a/Infinite_Villager_Trades/functions/ivt_spawn_trader.mcfunction
+++ b/Infinite_Villager_Trades/functions/ivt_spawn_trader.mcfunction
@@ -1,0 +1,7 @@
+# Triệu hồi thương nhân lang thang tại tọa độ cố định và gắn tag nhận diện
+summon minecraft:wandering_trader 58 110 137
+
+tag @e[type=wandering_trader,x=58,y=110,z=137,r=3,limit=1,sort=nearest] add ivt_custom_trader
+
+# Lên lịch tự động biến mất sau 15 phút (18000 ticks)
+schedule function ivt_despawn_trader 18000

--- a/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
+++ b/Infinite_Villager_Trades/trading/economy_trades/wandering_trader_trades.json
@@ -3,1527 +3,37 @@
     {
       "groups": [
         {
-          "num_to_select": 2,
+          "num_to_select": 1,
           "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:potion:0",
+                  "item": "minecraft:diamond",
                   "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:water_bucket",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:milk_bucket",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:fermented_spider_eye",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:baked_potato",
-                  "quantity": 4
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:hay_block",
-                  "quantity": 1
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            }
-          ]
-        },
-        {
-          "num_to_select": 2,
-          "trades": [
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:packed_ice",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_ice",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:gunpowder",
-                  "quantity": 4
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:podzol",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:acacia_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:birch_log:2",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dark_oak_log:1",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:jungle_log:3",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oak_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:spruce_log:1",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cherry_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_oak_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:mangrove_log",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.2
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:iron_pickaxe",
+                  "item": "minecraft:diamond_sword",
                   "quantity": 1,
                   "functions": [
                     {
-                      "function": "enchant_with_levels",
-                      "treasure": false,
-                      "levels": {
-                        "min": 5,
-                        "max": 19
-                      }
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "sharpness", "level": 5 },
+                        { "id": "smite", "level": 5 },
+                        { "id": "bane_of_arthropods", "level": 5 },
+                        { "id": "fire_aspect", "level": 2 },
+                        { "id": "looting", "level": 3 },
+                        { "id": "knockback", "level": 2 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
+                      ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 1,
-              "max_uses": 50,
-              "reward_exp": true
-            },
-            {
-              "max_uses": 50,
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:potion:8",
-                  "quantity": 1
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "num_to_select": 5,
-          "trades": [
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tropical_fish_bucket",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pufferfish_bucket",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sea_pickle",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:slime_ball",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:glowstone",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:nautilus_shell",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:fern",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tall_dry_grass",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sugar_cane",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pumpkin",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:kelp",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cactus",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dandelion",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:poppy",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_orchid",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:allium",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:azure_bluet",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:orange_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:white_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pink_tulip",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oxeye_daisy",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cornflower",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:wildflowers",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:firefly_bush",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:lily_of_the_valley",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:open_eyeblossom",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:wheat_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:beetroot_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pumpkin_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:melon_seeds",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:acacia_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:birch_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dark_oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:jungle_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:spruce_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cherry_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_oak_sapling",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 3,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:mangrove_propagule",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:white_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:blue_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pink_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:black_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:green_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:light_gray_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:magenta_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:yellow_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:gray_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:purple_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:light_blue_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:lime_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:orange_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brown_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:cyan_dye",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brain_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:bubble_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:fire_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:horn_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 2,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:tube_coral_block",
-                  "quantity": 1
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:vine",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_hanging_moss",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:brown_mushroom",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_mushroom",
-                  "quantity": 3
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:waterlily",
-                  "quantity": 5
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:small_dripleaf_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:sand",
-                  "quantity": 8
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:red_sand",
-                  "quantity": 4
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pointed_dripstone",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:dirt_with_roots",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:moss_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
-            },
-            {
-              "wants": [
-                {
-                  "item": "minecraft:emerald",
-                  "quantity": 1,
-                  "price_multiplier": 0.05
-                }
-              ],
-              "gives": [
-                {
-                  "item": "minecraft:pale_moss_block",
-                  "quantity": 2
-                }
-              ],
-              "max_uses": 50
+              "max_uses": 1
             }
           ]
         },
@@ -1533,89 +43,173 @@
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 8,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_helmet",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "mending",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "respiration", "level": 3 },
+                        { "id": "aqua_affinity", "level": 1 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 5,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
-            },
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 6,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_chestplate",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "frost_walker",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 3,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
-            },
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
             {
               "wants": [
                 {
-                  "item": "minecraft:emerald",
-                  "quantity": 6,
-                  "price_multiplier": 0.05
+                  "item": "minecraft:diamond",
+                  "quantity": 1
                 }
               ],
               "gives": [
                 {
-                  "item": "minecraft:book",
+                  "item": "minecraft:diamond_leggings",
                   "quantity": 1,
                   "functions": [
                     {
                       "function": "specific_enchants",
                       "enchants": [
-                        {
-                          "id": "soul_speed",
-                          "level": 1
-                        }
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "swift_sneak", "level": 3 }
                       ]
                     }
                   ]
                 }
               ],
-              "trader_exp": 3,
-              "max_uses": 10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000,
-              "reward_exp": true
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:diamond_boots",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "protection", "level": 4 },
+                        { "id": "fire_protection", "level": 4 },
+                        { "id": "blast_protection", "level": 4 },
+                        { "id": "projectile_protection", "level": 4 },
+                        { "id": "thorns", "level": 3 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "unbreaking", "level": 3 },
+                        { "id": "feather_falling", "level": 4 },
+                        { "id": "frost_walker", "level": 2 },
+                        { "id": "depth_strider", "level": 3 },
+                        { "id": "soul_speed", "level": 3 }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "max_uses": 1
+            }
+          ]
+        },
+        {
+          "num_to_select": 1,
+          "trades": [
+            {
+              "wants": [
+                {
+                  "item": "minecraft:diamond",
+                  "quantity": 1
+                }
+              ],
+              "gives": [
+                {
+                  "item": "minecraft:bow",
+                  "quantity": 1,
+                  "functions": [
+                    {
+                      "function": "specific_enchants",
+                      "enchants": [
+                        { "id": "infinity", "level": 1 },
+                        { "id": "mending", "level": 1 },
+                        { "id": "power", "level": 5 },
+                        { "id": "punch", "level": 2 },
+                        { "id": "flame", "level": 1 },
+                        { "id": "unbreaking", "level": 3 }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "max_uses": 1
             }
           ]
         }


### PR DESCRIPTION
### Motivation
- Provide a compact set of powerful, single-use Wandering Trader offers that sell custom enchanted diamond gear for exactly 1 diamond each so players can buy unique items once per trader spawn.
- Add utility mcfunctions to reliably summon a tagged custom wandering trader at a fixed location and auto-despawn it after a timed interval for predictable spawn/manage behavior.

### Description
- Replaced the large emerald-based trade table in `trading/economy_trades/wandering_trader_trades.json` with compact groups where each trade `wants` `minecraft:diamond` x1 and `gives` a single enchanted item (diamond sword, helmet, chestplate, leggings, boots, bow) using the `specific_enchants` function and set `max_uses` to `1` so each offer is single-use per trader spawn.
- Updated enchantment sets to match requested high-tier combinations (e.g., sword: `sharpness V`, `smite V`, `bane_of_arthropods V`, `mending`, `unbreaking III`, etc.; armor pieces: protection sets, `thorns III`, `mending`, `unbreaking III`; boots include `feather_falling`, `frost_walker`, `depth_strider`, etc.; bow: `infinity`, `mending`, `power V`, `punch II`, `flame`, `unbreaking III`).
- Added two mcfunctions under `functions/`: `ivt_spawn_trader.mcfunction` which summons a wandering trader at coordinates `58 110 137`, tags it `ivt_custom_trader`, and schedules an automatic despawn; and `ivt_despawn_trader.mcfunction` which removes the tagged trader when executed.

### Testing
- Automated tests: none were executed for these data/content changes.
- Note: recommended validation is to load the behavior pack in a Bedrock world or on a Bedrock Dedicated Server and confirm the Wandering Trader offers the new single-use diamond trades and that running `ivt_spawn_trader` summons a tagged trader which is removed after 18000 ticks by `ivt_despawn_trader`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6bc70d548330ab3bfe3a1f7afa67)