### PR TITLE
Distribute mending repairs across all equipped items

### DIFF
--- a/Better Mending - BP/scripts/betterMending.js
+++ b/Better Mending - BP/scripts/betterMending.js
@@ -1,41 +1,49 @@
-import { Player, system, world } from '@minecraft/server';
+import { system, world } from '@minecraft/server';
 
+const REPAIR_PER_XP = 6;
+const TICK_INTERVAL = 10;
 
-world.beforeEvents.itemUse.subscribe(eventData => {
-    const player = eventData.source;
+const lastXpByPlayer = new Map();
 
-    if ( !player.isSneaking ) return;
-    
+system.runInterval(() => {
+    for (const player of world.getAllPlayers()) {
+        const currentXp = player.getTotalXp();
+        const lastXp = lastXpByPlayer.get(player.id);
 
-    const mainHandSlotIndex = player.selectedSlotIndex;
-    const mainHandItem = player.getComponent("minecraft:inventory").container.getItem(mainHandSlotIndex);
-    
-    if ( !mainHandItem.getComponent("enchantable").hasEnchantment("mending") ) return;
+        if (lastXp === undefined) {
+            lastXpByPlayer.set(player.id, currentXp);
+            continue;
+        }
 
-    const itemCurrentDamage = mainHandItem.getComponent("durability").damage
+        if (currentXp <= lastXp) {
+            lastXpByPlayer.set(player.id, currentXp);
+            continue;
+        }
 
-    if ( itemCurrentDamage == 0) return;
+        const gainedXp = currentXp - lastXp;
+        const xpToSpend = gainedXp;
 
-    let currentLevelXp = player.getTotalXp()
+        if (xpToSpend <= 0) {
+            lastXpByPlayer.set(player.id, currentXp);
+            continue;
+        }
 
-    if ( currentLevelXp < 12 ) return;
+        const equipment = player.getComponent("equippable");
+        if (!equipment) {
+            lastXpByPlayer.set(player.id, currentXp);
+            continue;
+        }
 
-    const equipment = player.getComponent('equippable');
-
-    if ( itemCurrentDamage >= 24 ) {
-        currentLevelXp -= 12
-        removeExperience(player,currentLevelXp)
-        repairItem(mainHandItem,equipment, 24)
+        const xpSpent = repairWithXp(equipment, xpToSpend);
+        if (xpSpent > 0) {
+            const remainingXp = currentXp - xpSpent;
+            removeExperience(player, remainingXp);
+            lastXpByPlayer.set(player.id, remainingXp);
+        } else {
+            lastXpByPlayer.set(player.id, currentXp);
+        }
     }
-    else if ( itemCurrentDamage < 24 ) {
-        currentLevelXp -= itemCurrentDamage/2
-        removeExperience(player,currentLevelXp)
-        repairItem(mainHandItem,equipment, itemCurrentDamage)
-    }
-
-    eventData.cancel = true
-
-})
+}, TICK_INTERVAL);
 
 export function removeExperience(player, amount){
     system.run( () => {
@@ -44,10 +52,61 @@ export function removeExperience(player, amount){
     })
 }
 
-export function repairItem(mainHandItem, equipment, amount){
+function repairWithXp(equipment, xpAvailable) {
+    const slotsToRepair = [
+        "Mainhand",
+        "Offhand",
+        "Head",
+        "Chest",
+        "Legs",
+        "Feet",
+    ];
+
+    const itemsToRepair = [];
+
+    for (const slot of slotsToRepair) {
+        const item = equipment.getEquipment(slot);
+        if (!item) continue;
+
+        const enchantable = item.getComponent("enchantable");
+        if (!enchantable || !enchantable.hasEnchantment("mending")) continue;
+
+        const durability = item.getComponent("durability");
+        if (!durability || durability.damage <= 0) continue;
+
+        itemsToRepair.push({ item, slot });
+    }
+
+    if (itemsToRepair.length === 0) return 0;
+
+    let remainingXp = xpAvailable;
+    let totalXpUsed = 0;
+
+    while (remainingXp > 0) {
+        let repairedThisRound = false;
+
+        for (const { item, slot } of itemsToRepair) {
+            if (remainingXp <= 0) break;
+            const durability = item.getComponent("durability");
+            if (!durability || durability.damage <= 0) continue;
+
+            const repairAmount = Math.min(durability.damage, REPAIR_PER_XP);
+            repairItem(item, equipment, slot, repairAmount);
+            remainingXp -= 1;
+            totalXpUsed += 1;
+            repairedThisRound = true;
+        }
+
+        if (!repairedThisRound) break;
+    }
+
+    return totalXpUsed;
+}
+
+export function repairItem(item, equipment, slot, amount){
     system.run( () => {
-        const durability = mainHandItem.getComponent("durability")
+        const durability = item.getComponent("durability")
         durability.damage -= amount;
-        equipment.setEquipment('Mainhand', mainHandItem);
+        equipment.setEquipment(slot, item);
     })
 }


### PR DESCRIPTION
### Motivation
- Make mending repairs trigger reliably on actual XP gain instead of unreliable item-use/sneak activation.  
- Ensure all equipped slots (`Mainhand`, `Offhand`, `Head`, `Chest`, `Legs`, `Feet`) are eligible for mending, not just the main hand.  
- Allow all gained XP to be used for repairs rather than capping per cycle, while keeping CPU cost bounded using a periodic interval.  

### Description
- Track per-player XP with a `lastXpByPlayer` map and a periodic loop via `system.runInterval` (constant `TICK_INTERVAL`) to detect XP gains and trigger repairs.  
- Removed the previous per-cycle cap and now compute `gainedXp = currentXp - lastXp` and pass it to `repairWithXp` to consume all gained XP.  
- Implemented `repairWithXp` to gather all damaged items that have the `mending` enchantment across the configured slots and distribute XP in a round-robin fashion, using `REPAIR_PER_XP` durability per XP.  
- Kept `repairItem` and `removeExperience` implemented with `system.run` to safely mutate `durability` and player XP, and exported them for reuse.  
- Modified file: `scripts/betterMending.js` with the above logic and constants.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec727fa088330aaff9a4f5b4cbb56)